### PR TITLE
Fixed issue with rocket being launched after the console re-output

### DIFF
--- a/src/GitRocketTerminal.jsx
+++ b/src/GitRocketTerminal.jsx
@@ -15,7 +15,8 @@ function detectPushCommand(data) {
 exports.middleware = store => next => (action) => {
   if (action.type === 'SESSION_ADD_DATA') {
     const { data } = action;
-    if (detectPushCommand(data)) {
+    // The data length check verifies it is a push, not a duplicate output of the console
+    if (detectPushCommand(data) && data.length < 1000) {
       store.dispatch({
         type: 'PUSH_MODE_TOGGLE',
       });


### PR DESCRIPTION
Below is a normal push along with the length of the data that the `detectPushCommand` gets passed.

![gitrocketregularpushlength](https://user-images.githubusercontent.com/19258566/46592814-c2aa3680-ca8b-11e8-8549-a2046eb39ec7.png)

Note the length is 352. I've found most of mine are around 300 in length.

Now this next image will show the length of the data when the console is re-writing previous output.

![gitrocketoutputpushnotregular](https://user-images.githubusercontent.com/19258566/46592839-1026a380-ca8c-11e8-86b4-f3bb8f2ee6be.png)

The length of 2000 was about average in my testing. Simply adding a check that the data length is less than 1000 should solve the issue. I made it higher than my average push to account for longer file paths.